### PR TITLE
Refines guidance for code contributions and setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,7 +34,7 @@ This project uses `uv` for package and virtual environment management.
 -   **Linting:** `ruff check .`
 -   **Formatting:** `ruff format .`
 -   **Testing:** `pytest`
--   **Pre-Commit CI Check:** Before any commit, run formatting and linting. The CI pipeline will enforce these checks.
+-   **Pre-Commit CI Check:** Before any commit (and definitely do this after all other code changes), run formatting and linting. The CI pipeline will enforce these checks.
 
 ---
 
@@ -48,11 +48,11 @@ This project uses `uv` for package and virtual environment management.
 6.  **Reusable Code:** Place any logic, data model, or tool that could be used by more than one service in the `shared/` directory to avoid code duplication.
 7. **Documentation and comments:** When adding new documentation or comments to code, never reference the documents in the doc/project/epic_M/ folders.
 8. More on new **Documentation style:**  If something is explained in docs/project and docs/arch directories, it's fine to include a repeat of that detail in implementation documentation. BUT if something is explained in OTHER implementation documents (like plugins documentation, tutorials, etc.) that could be considered authoritative, then reference those instead of rewriting the content.
-9. **No Example code:** Rather than writing example code, write tutorial-blog style documents for inclusion in the docs/tutorials directory. If the code indicates how to add on or work with tools, a guide like the docs/guides/plugin_system_guide.md makes sense. If the task you are implementing is a fairly self-contained component of the projectm a document, instead of writing a README.md in the same directory as the code, use docs/components. To facilitate good style, please see an example in any of these directories before adding your own.
+9. **No Example code:** Rather than writing example code scripts, write tutorial-blog style documents for inclusion in the docs/tutorials directory. If the code indicates how to add on or work with tools, a guide like the docs/guides/plugin_system_guide.md makes sense. If the task you are implementing is a fairly self-contained component of the projectm a document, instead of writing a README.md in the same directory as the code, use docs/components. To facilitate good style, please see an example in any of these directories before adding your own.
 
 ---
 
-##  workflow:: Task Analysis & Implementation
+##  workflow: Task Analysis & Implementation
 
 When you receive a sprint task file, follow this precise workflow to plan and execute your work.
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  copilot-setup:
+  copilot-setup-steps:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Clarifies the pre-commit check instructions to emphasize its importance after all other code changes.

Updates documentation guidelines to discourage example code and promote tutorial-style documentation instead.

Renames a workflow for clarity.
