### PR TITLE
Uses uv to run pre-commit hooks

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,4 +31,4 @@ jobs:
         run: uv pip install -e ".[dev]"
 
       - name: Install pre-commit hooks
-        run: pre-commit install
+        run: uv run pre-commit install


### PR DESCRIPTION
Updates the copilot-setup-steps workflow to use `uv` for running pre-commit hooks.

This change ensures consistency with the rest of the workflow where `uv` is used as the package manager.
