### PR TITLE
Updates dependencies to use workspace definition

### DIFF
--- a/services/clarifai-core/pyproject.toml
+++ b/services/clarifai-core/pyproject.toml
@@ -7,7 +7,7 @@ name = "clarifai-core"
 version = "0.1.0"
 description = "Core processing engine for ClarifAI, including agentic capabilities."
 dependencies = [
-    "clarifai-shared"
+    "clarifai-shared = { workspace = true }"
 ]
 
 [tool.ruff]

--- a/services/clarifai-ui/pyproject.toml
+++ b/services/clarifai-ui/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "User interface for ClarifAI."
 dependencies = [
     "gradio",
-    "clarifai-shared"
+    "clarifai-shared = { workspace = true }"
 ]
 
 [project.scripts]

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -7,7 +7,7 @@ name = "clarifai-scheduler"
 version = "0.1.0"
 description = "Service for running scheduled background tasks."
 dependencies = [
-    "clarifai-shared",
+    "clarifai-shared = { workspace = true }",
     "apscheduler>=3.10.0",
     "python-dotenv>=1.0.0"
 ]

--- a/services/vault-watcher/pyproject.toml
+++ b/services/vault-watcher/pyproject.toml
@@ -7,7 +7,7 @@ name = "clarifai-vault-watcher"
 version = "0.1.0"
 description = "Service to monitor vault file changes."
 dependencies = [
-    "clarifai-shared"
+    "clarifai-shared = { workspace = true }"
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Updates the `clarifai-core`, `clarifai-ui`, `clarifai-scheduler`, and `clarifai-vault-watcher` projects to use the workspace definition for the `clarifai-shared` dependency.

This ensures that the projects use the same version of `clarifai-shared` from the workspace, promoting consistency and preventing version conflicts.
