### PR TITLE
Enables workspace `clarifai-shared` package usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ packages = [
   "services/vault-watcher/clarifai_vault_watcher",
 ]
 
+[tool.uv.sources]
+# This tells uv: "Any time any package asks for `clarifai-shared`,
+# don't go to PyPI. Instead, use the package from the local workspace."
+clarifai-shared = { workspace = true }
+
 [tool.uv.workspace]
 members = [
     "services/clarifai-core",

--- a/services/clarifai-core/pyproject.toml
+++ b/services/clarifai-core/pyproject.toml
@@ -7,7 +7,7 @@ name = "clarifai-core"
 version = "0.1.0"
 description = "Core processing engine for ClarifAI, including agentic capabilities."
 dependencies = [
-    "clarifai-shared = { workspace = true }"
+    "clarifai-shared"
 ]
 
 [tool.ruff]

--- a/services/clarifai-ui/pyproject.toml
+++ b/services/clarifai-ui/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "User interface for ClarifAI."
 dependencies = [
     "gradio",
-    "clarifai-shared = { workspace = true }"
+    "clarifai-shared"
 ]
 
 [project.scripts]

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -7,7 +7,7 @@ name = "clarifai-scheduler"
 version = "0.1.0"
 description = "Service for running scheduled background tasks."
 dependencies = [
-    "clarifai-shared = { workspace = true }",
+    "clarifai-shared",
     "apscheduler>=3.10.0",
     "python-dotenv>=1.0.0"
 ]

--- a/services/vault-watcher/pyproject.toml
+++ b/services/vault-watcher/pyproject.toml
@@ -7,7 +7,7 @@ name = "clarifai-vault-watcher"
 version = "0.1.0"
 description = "Service to monitor vault file changes."
 dependencies = [
-    "clarifai-shared = { workspace = true }"
+    "clarifai-shared"
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Configures the build system to utilize the local `clarifai-shared` package instead of fetching it from PyPI.

Removes the workspace declaration from individual service dependencies, and instead configures the top level `pyproject.toml` to point all dependencies to the workspace package.
