### PR TITLE
Removes pre-commit hook installation from workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,6 +29,3 @@ jobs:
         # to recognize and install dependencies from all member packages (services/* and shared/).
         # The `.[dev]` part installs the root project's dependencies plus its optional 'dev' dependencies.
         run: uv pip install -e ".[dev]"
-
-      - name: Install pre-commit hooks
-        run: uv run pre-commit install


### PR DESCRIPTION
The pre-commit hook installation step is removed from the workflow.

This simplifies the workflow and ensures pre-commit hooks are installed
consistently through other means (e.g., local development setup).
